### PR TITLE
fixed security warning and updated version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "undecorated-di",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "undecorated-di",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.3",
@@ -1082,9 +1082,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undecorated-di",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Type-safe, straightforward dependency injection for TypeScript without annotations or reflect-metadata.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
- Executed `npm audit fix` to fix security warning
- Updated the version number to 2.0.5 in package.json